### PR TITLE
Potential fix for code scanning alert no. 10: Missing rate limiting

### DIFF
--- a/owl-api/package.json
+++ b/owl-api/package.json
@@ -28,7 +28,8 @@
     "swagger-jsdoc": "^6.2.8",
     "swagger-ui-express": "^5.0.1",
     "typeorm": "^0.3.27",
-    "typescript": "^5.5.3"
+    "typescript": "^5.5.3",
+    "express-rate-limit": "^8.2.1"
   },
   "devDependencies": {
     "eslint": "^9.39.1",

--- a/owl-api/src/api/routes/windows.routes.ts
+++ b/owl-api/src/api/routes/windows.routes.ts
@@ -1,4 +1,5 @@
 import { Router } from 'express';
+import rateLimit from 'express-rate-limit';
 import {
   getWindowSensorsForUser,
   getWindowsHistory,
@@ -8,6 +9,13 @@ import { clerkAuthMiddleware } from '../middlewares/auth.middleware.js';
 
 const router = Router();
 
+// Define rate limiter: max 100 requests per 15 mins (per IP)
+const windowsLimiter = rateLimit({
+  windowMs: 15 * 60 * 1000, // 15 minutes
+  max: 100,
+  standardHeaders: true,
+  legacyHeaders: false,
+});
 /**
  * @swagger
  * tags:
@@ -31,7 +39,7 @@ const router = Router();
  *               items:
  *                 $ref: '#/components/schemas/Sensor'
  */
-router.get('/', clerkAuthMiddleware, getWindowSensorsForUser);
+router.get('/', windowsLimiter, clerkAuthMiddleware, getWindowSensorsForUser);
 
 /**
  * @swagger
@@ -64,7 +72,7 @@ router.get('/', clerkAuthMiddleware, getWindowSensorsForUser);
  *                   sensorName: { type: string }
  *                   hubName: { type: string }
  */
-router.get('/history', clerkAuthMiddleware, getWindowsHistory);
+router.get('/history', windowsLimiter, clerkAuthMiddleware, getWindowsHistory);
 
 /**
  * @swagger
@@ -92,6 +100,6 @@ router.get('/history', clerkAuthMiddleware, getWindowsHistory);
  *                   hour: { type: integer, example: 8 }
  *                   count: { type: integer, example: 12 }
  */
-router.get('/stats', clerkAuthMiddleware, getWindowsHourlyStats);
+router.get('/stats', windowsLimiter, clerkAuthMiddleware, getWindowsHourlyStats);
 
 export default router;


### PR DESCRIPTION
Potential fix for [https://github.com/BlacF0X/owl/security/code-scanning/10](https://github.com/BlacF0X/owl/security/code-scanning/10)

To address the missing rate limiting, we should add an Express-compatible rate-limiting middleware (such as `express-rate-limit`) to the relevant routes in `windows.routes.ts`. The best fix is to import `express-rate-limit`, instantiate a rate limiter with sensible defaults (e.g., 100 requests per 15 minutes per IP), and apply it to each route as a middleware, placed before the route handler (and likely before or after the auth middleware). This avoids changing existing functionality and provides protection for all three GET routes defined: `/`, `/history`, and `/stats`. The changes involve adding the import, defining the rate limiter variable, and updating each `router.get` line to include the limiter middleware.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
